### PR TITLE
Fix passphrase encoding issue

### DIFF
--- a/js/backup.js
+++ b/js/backup.js
@@ -16837,7 +16837,7 @@ function pbkdf2Sync (password, salt, iterations, keylen, digest) {
 
   digest = digest || 'sha1'
 
-  if (!Buffer.isBuffer(password)) password = new Buffer(password, 'binary')
+  if (!Buffer.isBuffer(password)) password = new Buffer(password, 'utf8')
   if (!Buffer.isBuffer(salt)) salt = new Buffer(salt, 'binary')
 
   var hLen


### PR DESCRIPTION
currently, the passphrase in the backup html page is encoded in "binary" (pure ASCII) leading to a different between the DBB-App (where we encode passphrase in utf-8).

This PR should fix this issue.