### PR TITLE
Add description of all keypaths in explanation

### DIFF
--- a/backup.html
+++ b/backup.html
@@ -54,75 +54,77 @@
             &nbsp;&nbsp;&nbsp;
             <button id="backup-clear-button" class="btn btn-default"><i class="fa fa-eraser"></i> Clear</button>
             <br><br>
-           
+
             <div class="placeholder">BIP32 extended master private key</div>
             <textarea id="backup-xpriv" class="text-input" rows="3" cols="70" wrap="hard" spellcheck="false" readonly></textarea>
             <br>
-            
+
             <div class="placeholder">Electrum recovery key</div>
             <textarea id="backup-electrum" class="text-input" rows="3" cols="70" wrap="hard" spellcheck="false" readonly></textarea>
             <br>
-            
+
             <div class="placeholder">Electrum recovery key for a multisig wallet</div>
             <textarea id="backup-electrum-multisig" class="text-input" rows="3" cols="70" wrap="hard" spellcheck="false" readonly></textarea>
             <br>
-            
+
             <div class="placeholder">Ethereum private keys</div>
             <textarea id="backup-ethereum-private-keys" class="text-input" rows="5" cols="70" spellcheck="false" readonly></textarea>
             <br><br>
-            
+
             <input type="text" id="backup-name" class="text-input" placeholder="wallet name" value="" spellcheck="false" />
             &nbsp;&nbsp;&nbsp;
             <button id="backup-export-button" class="btn btn-default"><i class="fa fa-download"></i> Export PDF</button>
             <br><br><br>
-            
+
             <small>
-                * To <b>recover your Bitcoin wallet without a Digital Bitbox</b>, 
-                enter the wallet backup text and password in the above boxes, click 'generate', 
+                * To <b>recover your Bitcoin wallet without a Digital Bitbox</b>,
+                enter the wallet backup text and password in the above boxes, click 'generate',
                 and import the recovery key into the Electrum software wallet.
                 <br><br>
-                * To <b>recover Ethereum without a Digital Bitbox</b>, 
-                enter the wallet backup text and password in the above boxes, click 'generate', 
-                and enter an Ethereum private key into MyEtherWallet. 
-                The order of private keys corresponds to the order of public addresses when 'viewing' a wallet in MyEtherWallet. 
+                * To <b>recover Ethereum without a Digital Bitbox</b>,
+                enter the wallet backup text and password in the above boxes, click 'generate',
+                and enter an Ethereum private key into MyEtherWallet.
+                The order of private keys corresponds to the order of public addresses when 'viewing' a wallet in MyEtherWallet.
                 <br><br>
-                * The backup is saved as a PDF file on the micro SD card for convenience. 
+                * The backup is saved as a PDF file on the micro SD card for convenience.
                 Plug the micro SD card into a trusted printer if you wish to also make a <b>paper backup</b>.
                 <br><br>
-                * To <b>load your own wallet</b> into a Digital Bitbox, put the PDF file 
+                * To <b>load your own wallet</b> into a Digital Bitbox, put the PDF file
                 on the micro SD card inside a folder named 'digitalbitbox' in the root directory.
                 Then, insert the SD card into the Digital Bitbox, and load your wallet using the desktop app.
-                <b>High quality randomness is crucial!</b> 
+                <b>High quality randomness is crucial!</b>
                 Otherwise, a thief may be able to guess your key and take your coins.
                 <br><br>
-                * A wallet is generated from the backup text and password using a modified BIP39 procedure. 
-                In particular, PBKDF2 strengthening is done twice (22,528 total rounds) for stronger protection. 
+                * A wallet is generated from the backup text and password using a modified BIP39 procedure.
+                In particular, PBKDF2 strengthening is done twice (22,528 total rounds) for stronger protection.
                 <br><br>
-                * Standard wallet addresses are generated following the BIP32 and BIP44 specifications. 
+                * Standard wallet addresses are generated following the BIP32 and BIP44 specifications.
+                The BIP32 extended master private key is <i>m</i>.
+                Electrum recovery keys are generated with <i>m/44'/0'/0'</i>.
                 For a multi-signature wallet, the base BIP32 key path is <i>m/100'/45'/0'</i>.
-                For Ethereum, the base BIP32 key path is <i>m/44'/60'/0'/0</i>.
+                For Ethereum, the base BIP32 key path is <i>m/44'/60'/0'/0</i>. The tool generates Ethereum keys <i>m/44'/60'/0'/0/0</i> through <i>m/44'/60'/0'/0/19</i>.
             </small>
             <br><br>
         </section>
-      
+
 
     </div>
-    
-    
-    <!--#include file="inc/footer.html" -->  
-    
-    
+
+
+    <!--#include file="inc/footer.html" -->
+
+
     <!-- JavaScript Files -->
     <script src="js/jquery-1.11.3.min.js"></script> <!-- include again for backup.zip file -->
-    <script src="js/jquery-ui-fade.min.js"></script> <!-- http://jqueryui.com/download/ --> 
+    <script src="js/jquery-ui-fade.min.js"></script> <!-- http://jqueryui.com/download/ -->
     <script src="js/base58check.js"></script>
-    <script src="js/sha512.js"></script> 
-    <script src="js/bitcoin-min.js"></script> 
-    <script src="js/bip32.js"></script> 
+    <script src="js/sha512.js"></script>
+    <script src="js/bitcoin-min.js"></script>
+    <script src="js/bip32.js"></script>
     <script src="js/bip39.js"></script>
     <script src="js/backup.js"></script>
-    
-    
+
+
 </body>
 
 </html>


### PR DESCRIPTION
    All the keys generated should have a proper description of their generating keypaths.
    This make it clearer for users that do not import their keys to electrum.