### PR TITLE
Add Travis CI with Docker

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,13 @@
+sudo: required
+
+services:
+  - docker
+
+addons:
+  apt:
+    packages:
+      - curl
+      - gnupg2
+
+script:
+- docker build --tag html_backup-ci -f Dockerfile.travis .

--- a/Dockerfile.travis
+++ b/Dockerfile.travis
@@ -1,0 +1,31 @@
+# Copyright 2018 Shift Devices AG
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# docker build --tag html_backup-ci -f Dockerfile.travis .
+#
+
+FROM debian:stretch
+ENV DEBIAN_FRONTEND noninteractive
+WORKDIR /app
+COPY . /app
+
+RUN apt update && apt install -y curl gnupg2 git coreutils
+RUN curl -sL https://deb.nodesource.com/setup_10.x | bash -
+RUN apt install -y nodejs
+RUN apt install -y npm
+RUN npm install -g browserify
+
+RUN npm list
+RUN browserify js/backup_in.js -o js/backup.js
+RUN sha256sum js/backup.js


### PR DESCRIPTION
This builds and outputs a sha256sum of the built `js/backup.js`.